### PR TITLE
added API token for quay bot

### DIFF
--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -79,6 +79,9 @@ orgs.newOrg('eclipse-bluechi') {
         orgs.newRepoSecret('PYPI_API_TOKEN') {
           value: "********",
         },
+        orgs.newRepoSecret('QUAY_BOT_API_TOKEN') {
+          value: "pass:bots/automotive.bluechi/quay.io/api-token",
+        },
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {


### PR DESCRIPTION
This PR adds the secret name for the quay.io bot token. 