### PR TITLE
change default branch for hashmap.c repo

### DIFF
--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -107,6 +107,7 @@ orgs.newOrg('eclipse-bluechi') {
       ],
     },
     orgs.newRepo('hashmap.c') {
+      default_branch: "master",
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
This PR changes the default branch for the `hashmap.c` repo to `master` (same as in the mirrored repo https://github.com/tidwall/hashmap.c)