### PR TITLE
Remove bluechi-snapshot webhook

### DIFF
--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -72,12 +72,6 @@ orgs.newOrg('eclipse-bluechi') {
             "push"
           ],
         },
-        orgs.newRepoWebhook('https://copr.fedorainfracloud.org/webhooks/github/102833/ac79d20a-773d-40cd-b6a2-2d1c4df747b2/') {
-          content_type: "json",
-          events+: [
-            "push"
-          ],
-        },
       ],
       secrets: [
         orgs.newRepoSecret('GH_RELEASE_TOKEN') {


### PR DESCRIPTION
Removes bluechi-snapshot webhook, which send event to start building
BlueChi RPMs in @centos-automotive-sig/bluechi-snapshot repo after PR
was merged. This is no longer needed, because packit integration should
build the packages and merge them into bluechi-snapshot repo.

Signed-off-by: Martin Perina <mperina@redhat.com>
