### PR TITLE
added repository for bluechi-on-yocto

### DIFF
--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -140,5 +140,30 @@ orgs.newOrg('eclipse-bluechi') {
         },
       ],
     },
+    orgs.newRepo('bluechi-on-yocto') {
+      allow_update_branch: false,
+      description: "Yocto recipe for BlueChi including a basic single-node configuration",
+      has_projects: false,
+      has_wiki: false,
+      secret_scanning: "disabled",
+      secret_scanning_push_protection: "disabled",
+      squash_merge_commit_title: "PR_TITLE",
+      topics+: [
+        "bluechi",
+        "yocto"
+      ],
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: 1,
+          required_status_checks+: [],
+          requires_conversation_resolution: true,
+          requires_linear_history: true,
+          requires_strict_status_checks: true,
+        },
+      ],
+    },
   ],
 }


### PR DESCRIPTION
This PR adds the `bluechi-on-yocto` repository to the [eclipse-bluechi organization](https://github.com/eclipse-bluechi) using roughly the same settings as for the [BlueChi repo](https://github.com/eclipse-bluechi/bluechi).

@lrossetti will be the maintainer of this repo. 