### PR TITLE
grant GITHUB_TOKEN write permissions

### DIFF
--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -11,6 +11,7 @@ orgs.newOrg('eclipse-bluechi') {
     web_commit_signoff_required: false,
     workflows+: {
       actions_can_approve_pull_request_reviews: false,
+      default_workflow_permissions: "write",
     },
   },
   _repositories+:: [


### PR DESCRIPTION
In order to enable GH workflows to add comments in PRs, set the `default_workflow_permissions: "write"`. One example can be seen in this PR: https://github.com/eclipse-bluechi/bluechi/pull/690 - to add the coverage results as a comment to the PR. Currently, it gets a 403 response. 
@netomi Is this the `default_workflow_permission` the right option in order to achieve this?