### PR TITLE
added COVERALLS_REPO_TOKEN to bluechi

### DIFF
--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -82,6 +82,9 @@ orgs.newOrg('eclipse-bluechi') {
         orgs.newRepoSecret('QUAY_BOT_API_TOKEN') {
           value: "pass:bots/automotive.bluechi/quay.io/api-token",
         },
+        orgs.newRepoSecret('COVERALLS_REPO_TOKEN') {
+          value: "tbd",
+        },
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {


### PR DESCRIPTION
This PR adds the `COVERALLS_REPO_TOKEN` to the bluechi repo. 

Note: The value is `TBD`. Send it via bitwarden to the EF member working on this. 