### PR TITLE
Update fedora webhook

### DIFF
--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -19,7 +19,7 @@ orgs.newOrg('automotive.bluechi', 'eclipse-bluechi') {
       events+: [
         "*"
       ],
-      secret: "********",
+      secret: "pass:bots/automotive.bluechi/fedoraproject.org/webhook-secret",
     },
   ],
   _repositories+:: [

--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -14,7 +14,7 @@ orgs.newOrg('automotive.bluechi', 'eclipse-bluechi') {
     },
   ],
   webhooks+: [
-    orgs.newRepoWebhook('https://webhook.fedoraproject.org/api/v1/messages/f424028a') {
+    orgs.newOrgWebhook('https://webhook.fedoraproject.org/api/v1/messages/f424028a') {
       content_type: "json",
       events+: [
         "*"

--- a/otterdog/eclipse-bluechi.jsonnet
+++ b/otterdog/eclipse-bluechi.jsonnet
@@ -13,6 +13,15 @@ orgs.newOrg('automotive.bluechi', 'eclipse-bluechi') {
       value: "pass:bots/automotive.bluechi/galaxy.ansible.com/api-token",
     },
   ],
+  webhooks+: [
+    orgs.newRepoWebhook('https://webhook.fedoraproject.org/api/v1/messages/f424028a') {
+      content_type: "json",
+      events+: [
+        "*"
+      ],
+      secret: "********",
+    },
+  ],
   _repositories+:: [
     orgs.newRepo('bluechi') {
       allow_update_branch: false,
@@ -30,13 +39,6 @@ orgs.newOrg('automotive.bluechi', 'eclipse-bluechi') {
         "systemd"
       ],
       webhooks: [
-        orgs.newRepoWebhook('https://apps.fedoraproject.org/github2fedmsg/webhook') {
-          content_type: "json",
-          events+: [
-            "*"
-          ],
-          secret: "********",
-        },
         orgs.newRepoWebhook('https://copr.fedorainfracloud.org/webhooks/github/82383/cc6b5f40-adf7-4168-a023-b500bfb8281a/') {
           content_type: "json",
           events+: [


### PR DESCRIPTION
The [GitHub2FedMsg](https://github.com/fedora-infra/github2fedmsg) has been deprecated and we need to switch to the new Webhook To Fedora Messaging. 

Relates to: https://github.com/eclipse-bluechi/bluechi/issues/980


@netomi @heurtematte I also have to update the secret for the webhook. Should I send the secret to you before or after merging this PR, considering the `secret` field needs to be updated as well?